### PR TITLE
Fix bug when pressing shift+tab on first result.

### DIFF
--- a/main.js
+++ b/main.js
@@ -38,7 +38,7 @@ document.addEventListener("keydown", (event) => {
         // Refocus on first result and reset loop
         newTarget = results[resultsLength - 1]
 
-        currentTargetIndex = resultsLength
+        currentTargetIndex = resultsLength - 1
       } else {
         // Move to next result
         currentTargetIndex--


### PR DESCRIPTION
## Bug

When the first google search result is highlighted, press shift+tab, then shift+tab again and the same (last) item will be selected.

## Cause

When jumping to the last item in the search result we were setting the index as:

```js
currentTargetIndex = resultsLength
```

This means that if there were 10 items, it was setting the selected index to `10`. This is a problem because we select them on a zero based index. So instead this should be `9`.